### PR TITLE
feat: allow command line args to be read from a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- feat: allow CLI parameters to be read from a file
+
 ## [0.17.0](https://github.com/Substra/substra-tools/releases/tag/0.17.0) - 2022-09-19
 
 ### Changed

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -162,7 +162,7 @@ def _generate_generic_algo_cli(interface):
             n_fake_samples=args.n_fake_samples,
         )
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
     _parser_add_default_arguments(parser)
     parser.set_defaults(func=_user_func)
 

--- a/substratools/metrics.py
+++ b/substratools/metrics.py
@@ -137,7 +137,7 @@ class MetricsWrapper(object):
 
 
 def _generate_cli():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(fromfile_prefix_chars='@')
     parser.add_argument(
         "--method-name",
         type=str,


### PR DESCRIPTION
Companion PRs:
- https://github.com/Substra/substra-tools/pull/55 (this PR) (main PR)
- https://github.com/Substra/substra/pull/279
- https://github.com/Substra/substra-backend/pull/473

---


This PR enables the following calling syntax

```sh
python algo.py @/tmp/arguments.txt
```

where /tmp/arguments.txt contains

```
--log-level
warning
--inputs
[<some_json>]
--outputs
[<some_json>]
...etc
```

This fixes issues that arise when the CLI argument list is longer than the maximum argument list supported by the OS.

﻿The advantages of this approach (over e.g. JSON serialization)  are that 1. it's less complex (no custom argument parsing code + no JSON overhead), and 2. it is backwards compatible: the traditional way to call substra-tools is still valid

```sh
python algo.py --log-level warning --inputs [<some_json>] --outputs [<some_json>]
```

For more information, see https://docs.python.org/3/library/argparse.html#fromfile-prefix-chars


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202596874518654