### PR TITLE
feat: uniformized inputs and outputs accross functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - feat: allow CLI parameters to be read from a file
 
+### CHANGED
+
+- BREAKING CHANGES:
+  - the opener only exposes `get_data` and `fake_data` methods.
+  - the results of the above method is passed under the `datasamples` keys within the `inputs` dict arg of all
+    tools methods (train, predict, aggregate, score).
+  - all method (train, predict, aggregate, score) now takes a `task_properties` argument (dict) in addition to
+    `inputs` and `outputs`.
+  - The `rank` of a task previously passed under the `rank` key within the inputs is now given in the `task_properties`
+    dict under the `rank` key.
+
 ## [0.17.0](https://github.com/Substra/substra-tools/releases/tag/0.17.0) - 2022-09-19
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,7 @@ pyclean:
 	find . -type d -name "__pycache__" -delete
 
 build: pyclean
-	docker build -f Dockerfile.minimal -t $(IMAGE):test_gt_arm64-minimal .
-	docker push $(IMAGE):test_gt_arm64-minimal
-	docker build -f Dockerfile -t $(IMAGE):test_gt_arm64 .
-	docker push $(IMAGE):test_gt_arm64
-	docker build -f Dockerfile.workflows -t $(IMAGE):test_gt_arm64-workflows .
-	docker push $(IMAGE):test_gt_arm64-workflows
-
+	docker build -t $(IMAGE):$(TAG) .
 
 test:
 	pytest tests

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,13 @@ pyclean:
 	find . -type d -name "__pycache__" -delete
 
 build: pyclean
-	docker build -t $(IMAGE):$(TAG) .
+	docker build -f Dockerfile.minimal -t $(IMAGE):test_gt_arm64-minimal .
+	docker push $(IMAGE):test_gt_arm64-minimal
+	docker build -f Dockerfile -t $(IMAGE):test_gt_arm64 .
+	docker push $(IMAGE):test_gt_arm64
+	docker build -f Dockerfile.workflows -t $(IMAGE):test_gt_arm64-workflows .
+	docker push $(IMAGE):test_gt_arm64-workflows
+
 
 test:
 	pytest tests

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -100,7 +100,7 @@ class GenericAlgoWrapper(object):
         # load inputs
         inputs = deepcopy(self._workspace.task_inputs)
 
-        task_properties = {StaticInputIdentifiers.rank: rank}
+        task_properties = {StaticInputIdentifiers.rank.value: rank}
 
         # load data from opener
         if self._opener_wrapper:
@@ -110,9 +110,9 @@ class GenericAlgoWrapper(object):
                 logger.info("Using fake data with %i fake samples." % int(n_fake_samples))
 
             assert (
-                StaticInputIdentifiers.datasamples not in inputs.keys()
-            ), f"{StaticInputIdentifiers.datasamples} must be an input of kind `datasamples`"
-            inputs.update({StaticInputIdentifiers.datasamples: loaded_datasamples})
+                StaticInputIdentifiers.datasamples.value not in inputs.keys()
+            ), f"{StaticInputIdentifiers.datasamples.value} must be an input of kind `datasamples`"
+            inputs.update({StaticInputIdentifiers.datasamples.value: loaded_datasamples})
 
         # load outputs
         outputs = deepcopy(self._workspace.task_outputs)

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -11,6 +11,7 @@ from substratools import exceptions
 from substratools import opener
 from substratools import utils
 from substratools.task_resources import TaskResources
+from substratools.task_resources import TASK_IO_DATASAMPLES
 from substratools.workspace import AlgoWorkspace
 
 logger = logging.getLogger(__name__)
@@ -99,18 +100,16 @@ class GenericAlgoWrapper(object):
         # load inputs
         inputs = deepcopy(self._workspace.task_inputs)
 
-        inputs.update({"rank": rank})
+        task_properties = {"rank": rank}
 
         # load data from opener
         if self._opener_wrapper:
-            X = self._opener_wrapper.get_X(fake_data, n_fake_samples)
-            y = self._opener_wrapper.get_y(fake_data, n_fake_samples)
+            loaded_datasamples = self._opener_wrapper.get_data(fake_data, n_fake_samples)
 
             if fake_data:
                 logger.info("Using fake data with %i fake samples." % int(n_fake_samples))
 
-            inputs.update({"X": X})
-            inputs.update({"y": y})
+            inputs.update({TASK_IO_DATASAMPLES: loaded_datasamples})
 
         # load outputs
         outputs = deepcopy(self._workspace.task_outputs)
@@ -122,6 +121,7 @@ class GenericAlgoWrapper(object):
         method(
             inputs=inputs,
             outputs=outputs,
+            task_properties=task_properties,
         )
 
         self._assert_outputs_exists(
@@ -175,6 +175,7 @@ class Algo(GenericAlgo):
         self,
         inputs: dict,
         outputs: dict,
+        task_properties: dict,
     ) -> None:
 
         raise NotImplementedError
@@ -184,6 +185,7 @@ class Algo(GenericAlgo):
         self,
         inputs: dict,
         outputs: dict,
+        task_properties: dict,
     ) -> None:
 
         raise NotImplementedError
@@ -195,6 +197,7 @@ class CompositeAlgo(GenericAlgo):
         self,
         inputs: dict,
         outputs: dict,
+        task_properties: dict,
     ) -> None:
 
         raise NotImplementedError
@@ -204,6 +207,7 @@ class CompositeAlgo(GenericAlgo):
         self,
         inputs: dict,
         outputs: dict,
+        task_properties: dict,
     ) -> None:
 
         raise NotImplementedError
@@ -215,6 +219,7 @@ class AggregateAlgo(GenericAlgo):
         self,
         inputs: dict,
         outputs: dict,
+        task_properties: dict,
     ) -> None:
 
         raise NotImplementedError
@@ -224,6 +229,7 @@ class AggregateAlgo(GenericAlgo):
         self,
         inputs: dict,
         outputs: dict,
+        task_properties: dict,
     ) -> None:
 
         raise NotImplementedError

--- a/substratools/algo.py
+++ b/substratools/algo.py
@@ -11,7 +11,7 @@ from substratools import exceptions
 from substratools import opener
 from substratools import utils
 from substratools.task_resources import TaskResources
-from substratools.task_resources import TASK_IO_DATASAMPLES
+from substratools.task_resources import StaticInputIdentifiers
 from substratools.workspace import AlgoWorkspace
 
 logger = logging.getLogger(__name__)
@@ -100,7 +100,7 @@ class GenericAlgoWrapper(object):
         # load inputs
         inputs = deepcopy(self._workspace.task_inputs)
 
-        task_properties = {"rank": rank}
+        task_properties = {StaticInputIdentifiers.rank: rank}
 
         # load data from opener
         if self._opener_wrapper:
@@ -109,7 +109,10 @@ class GenericAlgoWrapper(object):
             if fake_data:
                 logger.info("Using fake data with %i fake samples." % int(n_fake_samples))
 
-            inputs.update({TASK_IO_DATASAMPLES: loaded_datasamples})
+            assert (
+                StaticInputIdentifiers.datasamples not in inputs.keys()
+            ), f"{StaticInputIdentifiers.datasamples} must be an input of kind `datasamples`"
+            inputs.update({StaticInputIdentifiers.datasamples: loaded_datasamples})
 
         # load outputs
         outputs = deepcopy(self._workspace.task_outputs)

--- a/substratools/metrics.py
+++ b/substratools/metrics.py
@@ -131,7 +131,7 @@ class MetricsWrapper(object):
         inputs = {TASK_IO_DATASAMPLES: loaded_datasamples, _PREDICTIONS_IDENTIFIER: y_pred_path}
         outputs = {_PERFORMANCE_IDENTIFIER: self._workspace.output_perf_path}
 
-        self._interface.score(inputs, outputs, {})
+        self._interface.score(inputs=inputs, outputs=outputs, task_properties={})
 
         self._assert_output_exists(self._workspace.output_perf_path, _PERFORMANCE_IDENTIFIER)
 

--- a/substratools/metrics.py
+++ b/substratools/metrics.py
@@ -10,11 +10,11 @@ from substratools import exceptions
 from substratools import opener
 from substratools import utils
 from substratools.workspace import MetricsWorkspace
+from substratools.task_resources import TASK_IO_DATASAMPLES
 
 logger = logging.getLogger(__name__)
 REQUIRED_FUNCTIONS = set(["score"])
 
-_Y_IDENTIFIER = "y"
 _PREDICTIONS_IDENTIFIER = "predictions"
 _PERFORMANCE_IDENTIFIER = "performance"
 
@@ -38,8 +38,8 @@ class Metrics(abc.ABC):
 
 
     class AccuracyMetrics(tools.Metrics):
-        def score(self, inputs, outputs):
-            y_true = inputs["y"]
+        def score(self, inputs, outputs, task_properties):
+            y_true = inputs["datasamples"][1]
             y_pred = self.load_predictions(inputs["predictions"])
             perf = accuracy_score(y_true, y_pred)
             tools.save_performance(perf, outputs["performance"])
@@ -88,11 +88,11 @@ class Metrics(abc.ABC):
     data_sample_folders = os.listdir('./sandbox/data_samples/')
     predictions_path = './sandbox/predictions'
 
-    y_true = o.get_y(data_sample_folders)
+    y_true = o.get_data(data_sample_folders)[1]
 
     inputs = {"y": y_true, "predictions":predictions_path}
     outputs = {"performance": performance_path}
-    m.score(inputs, outputs)
+    m.score(inputs, outputs, task_properties)
     ```
     """
 
@@ -121,17 +121,17 @@ class MetricsWrapper(object):
         y_pred_path = self._workspace.input_predictions_path
 
         if not fake_data:
-            y = self._opener_wrapper.get_y()
+            loaded_datasamples = self._opener_wrapper.get_data()
 
         elif fake_data:
-            y = self._opener_wrapper.get_y(fake_data=True, n_fake_samples=n_fake_samples)
+            loaded_datasamples = self._opener_wrapper.get_data(fake_data=True, n_fake_samples=n_fake_samples)
 
         logger.info("launching scoring task")
 
-        inputs = {_Y_IDENTIFIER: y, _PREDICTIONS_IDENTIFIER: y_pred_path}
+        inputs = {TASK_IO_DATASAMPLES: loaded_datasamples, _PREDICTIONS_IDENTIFIER: y_pred_path}
         outputs = {_PERFORMANCE_IDENTIFIER: self._workspace.output_perf_path}
 
-        self._interface.score(inputs, outputs)
+        self._interface.score(inputs, outputs, {})
 
         self._assert_output_exists(self._workspace.output_perf_path, _PERFORMANCE_IDENTIFIER)
 

--- a/substratools/metrics.py
+++ b/substratools/metrics.py
@@ -10,7 +10,7 @@ from substratools import exceptions
 from substratools import opener
 from substratools import utils
 from substratools.workspace import MetricsWorkspace
-from substratools.task_resources import TASK_IO_DATASAMPLES
+from substratools.task_resources import StaticInputIdentifiers
 
 logger = logging.getLogger(__name__)
 REQUIRED_FUNCTIONS = set(["score"])
@@ -39,6 +39,7 @@ class Metrics(abc.ABC):
 
     class AccuracyMetrics(tools.Metrics):
         def score(self, inputs, outputs, task_properties):
+            # Here we are assuming that the opener `get_data` method returns a tuple (x, y)
             y_true = inputs["datasamples"][1]
             y_pred = self.load_predictions(inputs["predictions"])
             perf = accuracy_score(y_true, y_pred)
@@ -128,7 +129,7 @@ class MetricsWrapper(object):
 
         logger.info("launching scoring task")
 
-        inputs = {TASK_IO_DATASAMPLES: loaded_datasamples, _PREDICTIONS_IDENTIFIER: y_pred_path}
+        inputs = {StaticInputIdentifiers.datasamples: loaded_datasamples, _PREDICTIONS_IDENTIFIER: y_pred_path}
         outputs = {_PERFORMANCE_IDENTIFIER: self._workspace.output_perf_path}
 
         self._interface.score(inputs=inputs, outputs=outputs, task_properties={})

--- a/substratools/metrics.py
+++ b/substratools/metrics.py
@@ -129,7 +129,7 @@ class MetricsWrapper(object):
 
         logger.info("launching scoring task")
 
-        inputs = {StaticInputIdentifiers.datasamples: loaded_datasamples, _PREDICTIONS_IDENTIFIER: y_pred_path}
+        inputs = {StaticInputIdentifiers.datasamples.value: loaded_datasamples, _PREDICTIONS_IDENTIFIER: y_pred_path}
         outputs = {_PERFORMANCE_IDENTIFIER: self._workspace.output_perf_path}
 
         self._interface.score(inputs=inputs, outputs=outputs, task_properties={})

--- a/substratools/opener.py
+++ b/substratools/opener.py
@@ -13,10 +13,8 @@ logger = logging.getLogger(__name__)
 
 REQUIRED_FUNCTIONS = set(
     [
-        "get_X",
-        "get_y",
-        "fake_X",
-        "fake_y",
+        "get_data",
+        "fake_data",
     ]
 )
 
@@ -27,10 +25,8 @@ class Opener(abc.ABC):
     To define a new opener script, subclass this class and implement the
     following abstract methods:
 
-    - #Opener.get_X()
-    - #Opener.get_y()
-    - #Opener.fake_X()
-    - #Opener.fake_y()
+    - #Opener.get_data()
+    - #Opener.fake_data()
 
     # Example
 
@@ -43,22 +39,13 @@ class Opener(abc.ABC):
     import substratools as tools
 
     class DummyOpener(tools.Opener):
-        def get_X(self, folders):
+        def get_data(self, folders):
             return [
                 pd.read_csv(os.path.join(folder, 'train.csv'))
                 for folder in folders
             ]
 
-        def get_y(self, folders):
-            return [
-                pd.read_csv(os.path.join(folder, 'y.csv'))
-                for folder in folders
-            ]
-
-        def fake_X(self, n_samples):
-            return []  # compute random fake data
-
-        def fake_y(self, n_samples):
+        def fake_data(self, n_samples):
             return []  # compute random fake data
     ```
 
@@ -76,14 +63,13 @@ class Opener(abc.ABC):
     folders = os.listdir('./sandbox/data_samples/')
 
     o = MyOpener()
-    X = o.get_X(folders)
-    y = o.get_y(folders)
+    loaded_datasamples = o.get_data(folders)
     ```
     """
 
     @abc.abstractmethod
-    def get_X(self, folders):
-        """Load feature data from data sample folders.
+    def get_data(self, folders):
+        """Datasamples loader
 
         # Arguments
 
@@ -96,22 +82,8 @@ class Opener(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_y(self, folders):
-        """Load labels from data sample folders.
-
-        # Arguments
-
-        folders: list of folders. Each folder represents a data sample.
-
-        # Returns
-
-        data: data labels object.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def fake_X(self, n_samples):
-        """Generate a fake matrix of features for offline testing.
+    def fake_data(self, n_samples):
+        """Generate fake loaded datasamples for offline testing.
 
         # Arguments
 
@@ -119,21 +91,7 @@ class Opener(abc.ABC):
 
         # Returns
 
-        data: data labels object.
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def fake_y(self, n_samples):
-        """Generate a fake target variable vector for offline testing.
-
-        # Arguments
-
-        n_samples (int): number of samples to return
-
-        # Returns
-
-        data: data labels object.
+        data: data object.
         """
         raise NotImplementedError
 
@@ -151,21 +109,13 @@ class OpenerWrapper(object):
     def data_folder_paths(self):
         return self._workspace.input_data_folder_paths
 
-    def get_X(self, fake_data=False, n_fake_samples=None):
+    def get_data(self, fake_data=False, n_fake_samples=None):
         if fake_data:
-            logger.info("loading X from fake data")
-            return self._interface.fake_X(n_samples=n_fake_samples)
+            logger.info("loading data from fake data")
+            return self._interface.fake_data(n_samples=n_fake_samples)
         else:
-            logger.info("loading X from '{}'".format(self.data_folder_paths))
-            return self._interface.get_X(self.data_folder_paths)
-
-    def get_y(self, fake_data=False, n_fake_samples=None):
-        if fake_data:
-            logger.info("loading y from fake data")
-            return self._interface.fake_y(n_samples=n_fake_samples)
-        else:
-            logger.info("loading y from '{}'".format(self.data_folder_paths))
-            return self._interface.get_y(self.data_folder_paths)
+            logger.info("loading data from '{}'".format(self.data_folder_paths))
+            return self._interface.get_data(self.data_folder_paths)
 
     def _assert_output_exists(self, path, key):
 

--- a/substratools/task_resources.py
+++ b/substratools/task_resources.py
@@ -7,7 +7,7 @@ from substratools import exceptions
 from enum import Enum
 
 
-class StaticInputIdentifiers(Enum(str)):
+class StaticInputIdentifiers(str, Enum):
     opener = "opener"
     datasamples = "datasamples"
     chainkeys = "chainkeys"
@@ -78,9 +78,9 @@ class TaskResources:
 
         _check_resources_multiplicity(self._values)
 
-        self.opener_path = self.get_value(StaticInputIdentifiers.opener)
-        self.input_data_folder_paths = self.get_value(StaticInputIdentifiers.datasamples)
-        self.chainkeys_path = self.get_value(StaticInputIdentifiers.chainkeys)
+        self.opener_path = self.get_value(StaticInputIdentifiers.opener.value)
+        self.input_data_folder_paths = self.get_value(StaticInputIdentifiers.datasamples.value)
+        self.chainkeys_path = self.get_value(StaticInputIdentifiers.chainkeys.value)
 
     def get_value(self, key: str) -> Optional[Union[List[str], str]]:
         """Returns the value for a given key. Return None if there is no matching resource.
@@ -112,5 +112,9 @@ class TaskResources:
             k: self.get_value(k)
             for k in self._values.keys()
             if k
-            not in (StaticInputIdentifiers.opener, StaticInputIdentifiers.datasamples, StaticInputIdentifiers.chainkeys)
+            not in (
+                StaticInputIdentifiers.opener.value,
+                StaticInputIdentifiers.datasamples.value,
+                StaticInputIdentifiers.chainkeys.value,
+            )
         }

--- a/substratools/task_resources.py
+++ b/substratools/task_resources.py
@@ -4,10 +4,14 @@ from typing import List
 from typing import Optional
 from typing import Union
 from substratools import exceptions
+from enum import Enum
 
-TASK_IO_OPENER = "opener"
-TASK_IO_DATASAMPLES = "datasamples"
-TASK_IO_CHAINKEYS = "chainkeys"
+
+class StaticInputIdentifiers(Enum(str)):
+    opener = "opener"
+    datasamples = "datasamples"
+    chainkeys = "chainkeys"
+    rank = "rank"
 
 
 _RESOURCE_ID = "id"
@@ -74,9 +78,9 @@ class TaskResources:
 
         _check_resources_multiplicity(self._values)
 
-        self.opener_path = self.get_value(TASK_IO_OPENER)
-        self.input_data_folder_paths = self.get_value(TASK_IO_DATASAMPLES)
-        self.chainkeys_path = self.get_value(TASK_IO_CHAINKEYS)
+        self.opener_path = self.get_value(StaticInputIdentifiers.opener)
+        self.input_data_folder_paths = self.get_value(StaticInputIdentifiers.datasamples)
+        self.chainkeys_path = self.get_value(StaticInputIdentifiers.chainkeys)
 
     def get_value(self, key: str) -> Optional[Union[List[str], str]]:
         """Returns the value for a given key. Return None if there is no matching resource.
@@ -107,5 +111,6 @@ class TaskResources:
         return {
             k: self.get_value(k)
             for k in self._values.keys()
-            if k not in (TASK_IO_OPENER, TASK_IO_DATASAMPLES, TASK_IO_CHAINKEYS)
+            if k
+            not in (StaticInputIdentifiers.opener, StaticInputIdentifiers.datasamples, StaticInputIdentifiers.chainkeys)
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,17 +36,11 @@ import json
 from substratools import Opener
 
 class FakeOpener(Opener):
-    def get_X(self, folder):
-        return 'X'
+    def get_data(self, folder):
+        return 'X', list(range(0, 3))
 
-    def get_y(self, folder):
-        return list(range(0, 3))
-
-    def fake_X(self, n_samples):
-        return ['Xfake'] * n_samples
-
-    def fake_y(self, n_samples):
-        return [0] * n_samples
+    def fake_data(self, n_samples):
+        return ['Xfake'] * n_samples, [0] * n_samples
 """
 
 

--- a/tests/test_aggregatealgo.py
+++ b/tests/test_aggregatealgo.py
@@ -27,12 +27,10 @@ class DummyAggregateAlgo(algo.AggregateAlgo):
         self,
         inputs: TypedDict(
             "inputs",
-            {
-                InputIdentifiers.models: List[PathLike],
-                InputIdentifiers.rank: int,
-            },
+            {InputIdentifiers.models: List[PathLike]},
         ),
         outputs: TypedDict("outputs", {OutputIdentifiers.model: PathLike}),
+        task_properties: TypedDict("task_properties", {InputIdentifiers.rank: int}),
     ) -> None:
         if inputs:
             models = utils.load_models(paths=inputs.get(InputIdentifiers.models, []))
@@ -50,16 +48,17 @@ class DummyAggregateAlgo(algo.AggregateAlgo):
         inputs: TypedDict(
             "inputs",
             {
-                InputIdentifiers.X: Any,
+                InputIdentifiers.datasamples: Any,
                 InputIdentifiers.model: PathLike,
             },
         ),
         outputs: TypedDict("outputs", {OutputIdentifiers.model: PathLike}),
+        task_properties: TypedDict("task_properties", {InputIdentifiers.rank: int}),
     ):
         model = utils.load_model(path=inputs.get(OutputIdentifiers.model))
 
         # Predict
-        X = inputs.get(InputIdentifiers.X)
+        X = inputs.get(InputIdentifiers.datasamples)[0]
         pred = X * model["value"]
 
         # save predictions
@@ -67,7 +66,7 @@ class DummyAggregateAlgo(algo.AggregateAlgo):
 
 
 class NoSavedModelAggregateAlgo(DummyAggregateAlgo):
-    def aggregate(self, inputs, outputs):
+    def aggregate(self, inputs, outputs, task_properties):
 
         if inputs:
             models = utils.load_models(paths=inputs.get(InputIdentifiers.models, []))
@@ -82,7 +81,7 @@ class NoSavedModelAggregateAlgo(DummyAggregateAlgo):
 
 
 class WrongSavedModelAggregateAlgo(DummyAggregateAlgo):
-    def aggregate(self, inputs, outputs):
+    def aggregate(self, inputs, outputs, task_properties):
 
         if inputs:
             models = utils.load_models(paths=inputs.get(InputIdentifiers.models, []))

--- a/tests/test_algo.py
+++ b/tests/test_algo.py
@@ -12,7 +12,7 @@ import pytest
 from substratools import algo
 from substratools import exceptions
 from substratools import opener
-from substratools.task_resources import TASK_IO_DATASAMPLES
+from substratools.task_resources import StaticInputIdentifiers
 from substratools.task_resources import TaskResources
 from substratools.workspace import AlgoWorkspace
 from tests import utils
@@ -218,7 +218,7 @@ def test_predict(fake_data, expected_pred, n_fake_samples, create_models, output
 
 def test_execute_train(workdir, output_model_path):
     inputs = [
-        {"id": TASK_IO_DATASAMPLES, "value": str(workdir / "datasamples_unused"), "multiple": True},
+        {"id": StaticInputIdentifiers.datasamples, "value": str(workdir / "datasamples_unused"), "multiple": True},
     ]
     outputs = [
         {"id": OutputIdentifiers.model, "value": str(output_model_path), "multiple": False},

--- a/tests/test_algo.py
+++ b/tests/test_algo.py
@@ -218,7 +218,11 @@ def test_predict(fake_data, expected_pred, n_fake_samples, create_models, output
 
 def test_execute_train(workdir, output_model_path):
     inputs = [
-        {"id": StaticInputIdentifiers.datasamples, "value": str(workdir / "datasamples_unused"), "multiple": True},
+        {
+            "id": StaticInputIdentifiers.datasamples.value,
+            "value": str(workdir / "datasamples_unused"),
+            "multiple": True,
+        },
     ]
     outputs = [
         {"id": OutputIdentifiers.model, "value": str(output_model_path), "multiple": False},

--- a/tests/test_algo.py
+++ b/tests/test_algo.py
@@ -2,7 +2,7 @@ import json
 import shutil
 from os import PathLike
 from pathlib import Path
-from typing import Any
+from typing import Any, Tuple
 from typing import List
 from typing import Optional
 from typing import TypedDict
@@ -31,17 +31,16 @@ class DummyAlgo(algo.Algo):
         inputs: TypedDict(
             "inputs",
             {
-                InputIdentifiers.X: List["str"],  # cf valid_opener_code # TODO: rename "data" , del Y
-                InputIdentifiers.y: List[int],  # datasamples contains loaded datasamples, if any, or None
+                InputIdentifiers.datasamples: Tuple[List["str"], List[int]],  # cf valid_opener_code
                 InputIdentifiers.models: Optional[
                     PathLike
                 ],  # inputs contains a dict where keys are identifiers and values are paths on the disk
-                InputIdentifiers.rank: int,
             },
         ),
         outputs: TypedDict(
             "outputs", {OutputIdentifiers.model: PathLike}
         ),  # outputs contains a dict where keys are identifiers and values are paths on disk
+        task_properties: TypedDict("task_properties", {InputIdentifiers.rank: int}),
     ) -> None:
         # TODO: checks on data
         # load models
@@ -63,8 +62,9 @@ class DummyAlgo(algo.Algo):
 
     def predict(
         self,
-        inputs: TypedDict("inputs", {InputIdentifiers.X: Any, InputIdentifiers.model: List[PathLike]}),
+        inputs: TypedDict("inputs", {InputIdentifiers.datasamples: Any, InputIdentifiers.model: List[PathLike]}),
         outputs: TypedDict("outputs", {OutputIdentifiers.predictions: PathLike}),
+        task_properties: TypedDict("task_properties", {InputIdentifiers.rank: int}),
     ) -> None:
         # TODO: checks on data
 
@@ -72,7 +72,7 @@ class DummyAlgo(algo.Algo):
         model = utils.load_model(path=inputs.get(InputIdentifiers.model))
 
         # predict
-        X = inputs.get(InputIdentifiers.X)
+        X = inputs.get(InputIdentifiers.datasamples)[0]
         pred = X * model["value"]
 
         # save predictions
@@ -80,7 +80,7 @@ class DummyAlgo(algo.Algo):
 
 
 class NoSavedModelAlgo(DummyAlgo):
-    def train(self, inputs, outputs):
+    def train(self, inputs, outputs, task_properties):
         # TODO: checks on data
         # load models
         if inputs:
@@ -101,7 +101,7 @@ class NoSavedModelAlgo(DummyAlgo):
 
 
 class WrongSavedModelAlgo(DummyAlgo):
-    def train(self, inputs, outputs):
+    def train(self, inputs, outputs, task_properties):
         # TODO: checks on data
         # load models
         if inputs:

--- a/tests/test_compositealgo.py
+++ b/tests/test_compositealgo.py
@@ -8,7 +8,7 @@ import pytest
 
 from substratools import algo
 from substratools import exceptions
-from substratools.task_resources import TASK_IO_DATASAMPLES
+from substratools.task_resources import StaticInputIdentifiers
 from substratools.task_resources import TaskResources
 from substratools.workspace import AlgoWorkspace
 from substratools import opener

--- a/tests/test_compositealgo.py
+++ b/tests/test_compositealgo.py
@@ -23,12 +23,12 @@ def setup(valid_opener):
 
 
 class FakeDataAlgo(algo.CompositeAlgo):
-    def train(self, inputs, outputs):
-        utils.save_model(model=inputs[InputIdentifiers.X], path=outputs["local"])
-        utils.save_model(model=inputs[InputIdentifiers.y], path=outputs["shared"])
+    def train(self, inputs: dict, outputs: dict, task_properties: dict):
+        utils.save_model(model=inputs[InputIdentifiers.datasamples][0], path=outputs["local"])
+        utils.save_model(model=inputs[InputIdentifiers.datasamples][1], path=outputs["shared"])
 
-    def predict(self, inputs: dict, outputs: dict) -> None:
-        utils.save_model(model=inputs[InputIdentifiers.X], path=outputs["predictions"])
+    def predict(self, inputs: dict, outputs: dict, task_properties: dict) -> None:
+        utils.save_model(model=inputs[InputIdentifiers.datasamples][0], path=outputs["predictions"])
 
 
 class DummyCompositeAlgo(algo.CompositeAlgo):
@@ -37,11 +37,9 @@ class DummyCompositeAlgo(algo.CompositeAlgo):
         inputs: TypedDict(
             "inputs",
             {
-                InputIdentifiers.X: Any,
-                InputIdentifiers.y: Any,
+                InputIdentifiers.datasamples: Any,
                 InputIdentifiers.local: Optional[os.PathLike],
                 InputIdentifiers.shared: Optional[os.PathLike],
-                InputIdentifiers.rank: int,
             },
         ),
         outputs: TypedDict(
@@ -51,6 +49,7 @@ class DummyCompositeAlgo(algo.CompositeAlgo):
                 OutputIdentifiers.shared: os.PathLike,
             },
         ),
+        task_properties: TypedDict("task_properties", {InputIdentifiers.rank: int}),
     ):
         # init phase
         # load models
@@ -77,7 +76,7 @@ class DummyCompositeAlgo(algo.CompositeAlgo):
         inputs: TypedDict(
             "inputs",
             {
-                InputIdentifiers.X: Any,
+                InputIdentifiers.datasamples: Any,
                 InputIdentifiers.local: os.PathLike,
                 InputIdentifiers.shared: os.PathLike,
             },
@@ -102,7 +101,7 @@ class DummyCompositeAlgo(algo.CompositeAlgo):
 
 
 class NoSavedTrunkModelAggregateAlgo(DummyCompositeAlgo):
-    def train(self, inputs, outputs):
+    def train(self, inputs, outputs, task_properties):
         # init phase
         # load models
         head_model = utils.load_model(path=inputs.get(InputIdentifiers.local))
@@ -125,7 +124,7 @@ class NoSavedTrunkModelAggregateAlgo(DummyCompositeAlgo):
 
 
 class NoSavedHeadModelAggregateAlgo(DummyCompositeAlgo):
-    def train(self, inputs, outputs):
+    def train(self, inputs, outputs, task_properties):
         # init phase
         # load models
         head_model = utils.load_model(path=inputs.get(InputIdentifiers.local))
@@ -148,7 +147,7 @@ class NoSavedHeadModelAggregateAlgo(DummyCompositeAlgo):
 
 
 class WrongSavedTrunkModelAggregateAlgo(DummyCompositeAlgo):
-    def train(self, inputs, outputs):
+    def train(self, inputs, outputs, task_properties):
         # init phase
         # load models
         head_model = utils.load_model(path=inputs.get(InputIdentifiers.local))
@@ -171,7 +170,7 @@ class WrongSavedTrunkModelAggregateAlgo(DummyCompositeAlgo):
 
 
 class WrongSavedHeadModelAggregateAlgo(DummyCompositeAlgo):
-    def train(self, inputs, outputs):
+    def train(self, inputs, outputs, task_properties):
         # init phase
         # load models
         head_model = utils.load_model(path=inputs.get(InputIdentifiers.local))
@@ -292,8 +291,8 @@ def test_train_fake_data(train_outputs, n_fake_samples):
     local_model = utils.load_model(dummy_train_wrapper._workspace.task_outputs[OutputIdentifiers.local])
     shared_model = utils.load_model(dummy_train_wrapper._workspace.task_outputs[OutputIdentifiers.shared])
 
-    assert local_model == _opener.get_X(fake_data=bool(n_fake_samples), n_fake_samples=n_fake_samples)
-    assert shared_model == _opener.get_y(fake_data=bool(n_fake_samples), n_fake_samples=n_fake_samples)
+    assert local_model == _opener.get_data(fake_data=bool(n_fake_samples), n_fake_samples=n_fake_samples)[0]
+    assert shared_model == _opener.get_data(fake_data=bool(n_fake_samples), n_fake_samples=n_fake_samples)[1]
 
 
 @pytest.mark.parametrize("n_fake_samples", (0, 1, 2))
@@ -306,7 +305,7 @@ def test_predict_fake_data(composite_inputs, predict_outputs, n_fake_samples):
 
     predictions = utils.load_model(dummy_train_wrapper._workspace.task_outputs[OutputIdentifiers.predictions])
 
-    assert predictions == _opener.get_X(fake_data=bool(n_fake_samples), n_fake_samples=n_fake_samples)
+    assert predictions == _opener.get_data(fake_data=bool(n_fake_samples), n_fake_samples=n_fake_samples)[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -36,8 +36,8 @@ from tests.utils import InputIdentifiers
 from tests.utils import OutputIdentifiers
 
 class FloatMetrics(Metrics):
-    def score(self, inputs, outputs):
-        y_true = inputs.get(InputIdentifiers.y)
+    def score(self, inputs, outputs, task_properties):
+        y_true = inputs.get(InputIdentifiers.datasamples)[1]
         y_pred_path = inputs.get(InputIdentifiers.predictions)
         y_pred = utils.load_predictions(y_pred_path)
         s = sum(y_true) + sum(y_pred)
@@ -57,7 +57,7 @@ from substratools import save_performance
 from tests.utils import OutputIdentifiers
 
 class FloatNpMetrics(Metrics):
-    def score(self, inputs, outputs):
+    def score(self, inputs, outputs, task_properties):
         save_performance(np.float64(0.99), outputs.get(OutputIdentifiers.performance))
 """
     import_module("metrics", code)
@@ -73,7 +73,7 @@ from substratools import save_performance
 from tests.utils import OutputIdentifiers
 
 class IntMetrics(Metrics):
-    def score(self, inputs, outputs):
+    def score(self, inputs, outputs, task_properties):
         save_performance(int(1), outputs.get(OutputIdentifiers.performance))
 """
     import_module("metrics", code)
@@ -89,7 +89,7 @@ from substratools import save_performance
 from tests.utils import OutputIdentifiers
 
 class DictMetrics(Metrics):
-    def score(self, inputs, outputs):
+    def score(self, inputs, outputs, task_properties):
         save_performance({"a": 1}, outputs.get(OutputIdentifiers.performance))
 """
     import_module("metrics", code)
@@ -105,10 +105,11 @@ def setup(valid_opener, write_pred_file):
 class DummyMetrics(metrics.Metrics):
     def score(
         self,
-        inputs: TypedDict("inputs", {InputIdentifiers.y: Any, InputIdentifiers.predictions: Any}),
+        inputs: TypedDict("inputs", {InputIdentifiers.datasamples: Any, InputIdentifiers.predictions: Any}),
         outputs: TypedDict("outputs", {OutputIdentifiers.performance: PathLike}),
+        task_properties: TypedDict("task_properties", {InputIdentifiers.rank: int}),
     ):
-        y_true = inputs.get(InputIdentifiers.y)
+        y_true = inputs.get(InputIdentifiers.datasamples)[1]
         y_pred_path = inputs.get(InputIdentifiers.predictions)
         y_pred = utils.load_predictions(y_pred_path)
 

--- a/tests/test_opener.py
+++ b/tests/test_opener.py
@@ -32,9 +32,7 @@ def test_load_opener_not_found(tmp_cwd):
 
 def test_load_invalid_opener(tmp_cwd):
     invalid_script = """
-def get_X():
-    raise NotImplementedError
-def get_y():
+def get_data():
     raise NotImplementedError
 """
 
@@ -44,45 +42,20 @@ def get_y():
         load_from_module()
 
 
-@pytest.mark.skip(reason="not supported")
-def test_load_opener_as_module(tmp_cwd):
-    script = """
-def _helper():
-    pass
-def get_X(folders):
-    return 'X'
-def get_y(folders):
-    return 'y'
-def fake_X(n_samples):
-    return 'fakeX'
-def fake_y(n_samples):
-    return 'fakey'
-"""
-
-    import_module("opener", script)
-
-    o = load_from_module()
-    assert o.get_X() == "X"
-
-
 def test_load_opener_as_class(tmp_cwd):
     script = """
 from substratools import Opener
 class MyOpener(Opener):
-    def get_X(self, folders):
-        return 'Xclass'
-    def get_y(self, folders):
-        return 'yclass'
-    def fake_X(self, n_samples):
-        return 'fakeX'
-    def fake_y(self, n_samples):
-        return 'fakey'
+    def get_data(self, folders):
+        return 'data_class'
+    def fake_data(self, n_samples):
+        return 'fake_data'
 """
 
     import_module("opener", script)
 
     o = load_from_module()
-    assert o.get_X() == "Xclass"
+    assert o.get_data() == "data_class"
 
 
 def test_load_opener_from_path(tmp_cwd, valid_opener_code):
@@ -98,22 +71,18 @@ def test_load_opener_from_path(tmp_cwd, valid_opener_code):
         path=path,
     )
     o = OpenerWrapper(interface, workspace=None)
-    assert o.get_X() == "X"
+    assert o.get_data()[0] == "X"
 
 
 def test_opener_check_folders(tmp_cwd):
     script = """
 from substratools import Opener
 class MyOpener(Opener):
-    def get_X(self, folders):
+    def get_data(self, folders):
         assert len(folders) == 5
-        return 'Xclass'
-    def get_y(self, folders):
-        return 'yclass'
-    def fake_X(self, n_samples):
-        return 'fakeX'
-    def fake_y(self, n_samples):
-        return 'fakey'
+        return 'data_class'
+    def fake_data(self, n_samples):
+        return 'fake_data_class'
 """
 
     import_module("opener", script)
@@ -126,4 +95,4 @@ class MyOpener(Opener):
     [os.makedirs(p) for p in data_paths]
 
     o._workspace.input_data_folder_paths = data_paths
-    assert o.get_X() == "Xclass"
+    assert o.get_data() == "data_class"

--- a/tests/test_task_resources.py
+++ b/tests/test_task_resources.py
@@ -47,7 +47,11 @@ def test_task_resources_values(valid_arg, expected):
 
 @pytest.mark.parametrize(
     "static_resource_id",
-    (StaticInputIdentifiers.chainkeys, StaticInputIdentifiers.datasamples, StaticInputIdentifiers.opener),
+    (
+        StaticInputIdentifiers.chainkeys.value,
+        StaticInputIdentifiers.datasamples.value,
+        StaticInputIdentifiers.opener.value,
+    ),
 )
 def test_task_static_resources(static_resource_id):
     "checks that static keys opener, datasamples and chainkeys are excluded"

--- a/tests/test_task_resources.py
+++ b/tests/test_task_resources.py
@@ -1,7 +1,5 @@
 from substratools.task_resources import TaskResources
-from substratools.task_resources import TASK_IO_CHAINKEYS
-from substratools.task_resources import TASK_IO_DATASAMPLES
-from substratools.task_resources import TASK_IO_OPENER
+from substratools.task_resources import StaticInputIdentifiers
 import pytest
 from substratools.exceptions import InvalidCLIError
 from substratools.exceptions import InvalidInputOutputsError
@@ -47,7 +45,10 @@ def test_task_resources_values(valid_arg, expected):
     TaskResources(json.dumps(valid_arg))._values == expected
 
 
-@pytest.mark.parametrize("static_resource_id", (TASK_IO_CHAINKEYS, TASK_IO_DATASAMPLES, TASK_IO_OPENER))
+@pytest.mark.parametrize(
+    "static_resource_id",
+    (StaticInputIdentifiers.chainkeys, StaticInputIdentifiers.datasamples, StaticInputIdentifiers.opener),
+)
 def test_task_static_resources(static_resource_id):
     "checks that static keys opener, datasamples and chainkeys are excluded"
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -26,16 +26,10 @@ import json
 from substratools import Opener
 
 class DummyOpener(Opener):
-    def get_X(self, folder):
+    def get_data(self, folder):
         return None
 
-    def get_y(self, folder):
-        return None
-
-    def fake_X(self, n_samples):
-        raise NotImplementedError
-
-    def fake_y(self, n_samples):
+    def fake_data(self, n_samples):
         raise NotImplementedError
 """
     import_module("opener", script)
@@ -43,7 +37,7 @@ class DummyOpener(Opener):
 
 # TODO change algo
 class DummyAlgo(Algo):
-    def train(self, inputs, outputs):
+    def train(self, inputs, outputs, task_properties):
 
         models = utils.load_models(inputs.get(InputIdentifiers.models, []))
         total = sum([m["i"] for m in models])
@@ -51,14 +45,14 @@ class DummyAlgo(Algo):
 
         utils.save_model(new_model, outputs.get(OutputIdentifiers.model))
 
-    def predict(self, inputs, outputs):
+    def predict(self, inputs, outputs, task_properties):
         model = utils.load_model(inputs.get(InputIdentifiers.model))
         pred = {"sum": model["i"]}
         utils.save_predictions(pred, outputs.get(OutputIdentifiers.predictions))
 
 
 class DummyMetrics(Metrics):
-    def score(self, inputs, outputs):
+    def score(self, inputs, outputs, task_properties):
         y_pred_path = inputs.get(InputIdentifiers.predictions)
         y_pred = utils.load_predictions(y_pred_path)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,6 @@ from typing import List
 from enum import Enum
 
 from substratools.metrics import _PERFORMANCE_IDENTIFIER
-from substratools.metrics import _Y_IDENTIFIER
 from substratools.metrics import _PREDICTIONS_IDENTIFIER
 
 
@@ -17,8 +16,6 @@ class InputIdentifiers(str, Enum):
     predictions = _PREDICTIONS_IDENTIFIER
     opener = "opener"
     datasamples = "datasamples"
-    X = "X"
-    y = _Y_IDENTIFIER
     rank = "rank"
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ from enum import Enum
 
 from substratools.metrics import _PERFORMANCE_IDENTIFIER
 from substratools.metrics import _PREDICTIONS_IDENTIFIER
+from substratools.task_resources import StaticInputIdentifiers
 
 
 class InputIdentifiers(str, Enum):
@@ -14,9 +15,9 @@ class InputIdentifiers(str, Enum):
     model = "model"
     models = "models"
     predictions = _PREDICTIONS_IDENTIFIER
-    opener = "opener"
-    datasamples = "datasamples"
-    rank = "rank"
+    opener = StaticInputIdentifiers.opener
+    datasamples = StaticInputIdentifiers.datasamples
+    rank = StaticInputIdentifiers.rank
 
 
 class OutputIdentifiers(str, Enum):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,9 +15,9 @@ class InputIdentifiers(str, Enum):
     model = "model"
     models = "models"
     predictions = _PREDICTIONS_IDENTIFIER
-    opener = StaticInputIdentifiers.opener
-    datasamples = StaticInputIdentifiers.datasamples
-    rank = StaticInputIdentifiers.rank
+    opener = StaticInputIdentifiers.opener.value
+    datasamples = StaticInputIdentifiers.datasamples.value
+    rank = StaticInputIdentifiers.rank.value
 
 
 class OutputIdentifiers(str, Enum):


### PR DESCRIPTION
Use `datasamples` as input identifiers for X and y accros all functions. 
Pass `rank` within a new argument named `task_properties`

Companion PRs: 
- substra https://github.com/Substra/substra/pull/284
- substrafl https://github.com/Substra/substrafl/pull/20
- substra-tests: https://github.com/Substra/substra-tests/pull/207
- substra-tools (main, here) https://github.com/Substra/substra-tools/pull/58
- substra-documentation: https://github.com/Substra/substra-documentation/pull/179