### PR TITLE
feat: add python 3.10 support

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Add a version to this list to automatically build Dockerfiles from it for the next releases
-      default_cuda_images: '["nvidia/cuda:11.6.0-base-ubuntu20.04"]'
-      default_python_versions: '["3.8", "3.9"]'
+      default_cuda_images: '["nvidia/cuda:11.8.0-base-ubuntu22.04"]'
+      default_python_versions: '["3.8", "3.9", "3.10"]'
     steps:
       - run: true
 

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -51,7 +51,7 @@ jobs:
           if [ $SUBSTRA_TOOLS_REF = "main" ]; then
             echo "IMG_BASE_TAG=latest-$CUDA_IMAGE_TAG-python${{ matrix.python_version }}" >> $GITHUB_ENV
             # Set the most recent image to latest, latest-minimal, latest-workflows
-            if [ "${{ matrix.cuda_image }}" == "nvidia/cuda:11.6.0-base-ubuntu20.04" ] &&  [ "${{ matrix.python_version }}" == "3.9" ]; then
+            if [ "${{ matrix.cuda_image }}" == "nvidia/cuda:11.8.0-base-ubuntu22.04" ] &&  [ "${{ matrix.python_version }}" == "3.10" ]; then
               echo "LATEST_TAG=latest" >> $GITHUB_ENV
             fi
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
 - Update flake8 repository in pre-commit configuration (#69)
+- BREAKING CHANGE: Update substratools Docker image (#112)
 
 ## [0.18.0](https://github.com/Substra/substra-tools/releases/tag/0.18.0) - 2022-09-26
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM $CUDA_IMAGE
 ARG PYTHON_VERSION=3.10
 # TODO: find a way to parse this from the CUDA_IMAGE
 # with bash string manipulation: ${CUDA_IMAGE##*-}//.
-ARG DISTRO=ubuntu2004
+ARG DISTRO=ubuntu2204
 
 ARG USER_ID=1001
 ARG GROUP_ID=1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Modified by .github/workflows/publish_docker.yml
-ARG CUDA_IMAGE=nvidia/cuda:11.6.0-base-ubuntu20.04
+ARG CUDA_IMAGE=nvidia/cuda:11.8.0-base-ubuntu22.04
 FROM $CUDA_IMAGE
 
 # Modified by .github/workflows/publish_docker.yml
-ARG PYTHON_VERSION=3.8
+ARG PYTHON_VERSION=3.10
 # TODO: find a way to parse this from the CUDA_IMAGE
 # with bash string manipulation: ${CUDA_IMAGE##*-}//.
 ARG DISTRO=ubuntu2004

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -6,7 +6,7 @@ FROM $CUDA_IMAGE
 ARG PYTHON_VERSION=3.10
 # TODO: find a way to parse this from the CUDA_IMAGE
 # with bash string manipulation: ${CUDA_IMAGE##*-}//.
-ARG DISTRO=ubuntu2004
+ARG DISTRO=ubuntu2204
 
 ARG USER_ID=1001
 ARG GROUP_ID=1001

--- a/Dockerfile.minimal
+++ b/Dockerfile.minimal
@@ -1,9 +1,9 @@
 # Modified by .github/workflows/publish_docker.yml
-ARG CUDA_IMAGE=nvidia/cuda:11.6.0-base-ubuntu20.04
+ARG CUDA_IMAGE=nvidia/cuda:11.8.0-base-ubuntu22.04
 FROM $CUDA_IMAGE
 
 # Modified by .github/workflows/publish_docker.yml
-ARG PYTHON_VERSION=3.8
+ARG PYTHON_VERSION=3.10
 # TODO: find a way to parse this from the CUDA_IMAGE
 # with bash string manipulation: ${CUDA_IMAGE##*-}//.
 ARG DISTRO=ubuntu2004

--- a/Dockerfile.workflows
+++ b/Dockerfile.workflows
@@ -6,7 +6,7 @@ FROM $CUDA_IMAGE
 ARG PYTHON_VERSION=3.10
 # TODO: find a way to parse this from the CUDA_IMAGE
 # with bash string manipulation: ${CUDA_IMAGE##*-}//.
-ARG DISTRO=ubuntu2004
+ARG DISTRO=ubuntu2204
 
 ARG USER_ID=1001
 ARG GROUP_ID=1001

--- a/Dockerfile.workflows
+++ b/Dockerfile.workflows
@@ -1,9 +1,9 @@
 # Modified by .github/workflows/publish_docker.yml
-ARG CUDA_IMAGE=nvidia/cuda:11.6.0-base-ubuntu20.04
+ARG CUDA_IMAGE=nvidia/cuda:11.8.0-base-ubuntu22.04
 FROM $CUDA_IMAGE
 
 # Modified by .github/workflows/publish_docker.yml
-ARG PYTHON_VERSION=3.8
+ARG PYTHON_VERSION=3.10
 # TODO: find a way to parse this from the CUDA_IMAGE
 # with bash string manipulation: ${CUDA_IMAGE##*-}//.
 ARG DISTRO=ubuntu2004

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install substratools
 ## Pull the substra-tools Docker image
 
 ```sh
-docker pull ghcr.io/substra/substra-tools:0.16.0-nvidiacuda11.6.0-base-ubuntu20.04-python3.9-workflows
+docker pull ghcr.io/substra/substra-tools:0.16.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9-workflows
 ```
 
 ## Developers

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install substratools
 ## Pull the substra-tools Docker image
 
 ```sh
-docker pull ghcr.io/substra/substra-tools:0.16.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.9-workflows
+docker pull ghcr.io/substra/substra-tools:0.16.0-nvidiacuda11.8.0-base-ubuntu22.04-python3.10-workflows
 ```
 
 ## Developers


### PR DESCRIPTION
## Summary

Generate Docker images using new Ubuntu LTS (22.04) and adding python 3.10 support

## Companion PR

- https://github.com/Substra/substra/pull/316
- https://github.com/Substra/substrafl/pull/49
- https://github.com/Substra/substra-documentation/pull/222
- https://github.com/Substra/substra-tests/pull/230