### PR TITLE
build: update flake8 repo in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: black
         args: [--line-length=120]
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
       - id: flake8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     tools.execute(my_function1, my_function2)
   ```
 
+- Update flake8 repository in pre-commit configuration (#69)
+
 ## [0.18.0](https://github.com/Substra/substra-tools/releases/tag/0.18.0) - 2022-09-26
 
 ### Added


### PR DESCRIPTION
Signed-off-by: Guilhem Barthes <guilhem.barthes@owkin.com>

## Summary

Update flake8 repository from the previous one hosted on GitLab to the new one on GitHub.