### PR TITLE
feat: add user define function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Add optional argument to ``register`` decorator to choose a custom function name. Allow to register the same function several time with a different name (#74)
 - Rank is now passed in a task properties dictionary from the backend (instead of the rank argument) (#75)
 
 ## [0.19.0](https://github.com/Substra/substra-tools/releases/tag/0.19.0) - 2022-11-22

--- a/substratools/function.py
+++ b/substratools/function.py
@@ -82,7 +82,7 @@ class FunctionRegister:
     def __init__(self):
         self._functions = {}
 
-    def __call__(self, function: Callable):
+    def __call__(self, function: Callable, function_name: Optional = None):
         """Function called when using an instance of the class as a decorator.
 
         Args:
@@ -96,8 +96,9 @@ class FunctionRegister:
             Callable: returns the function without decorator
         """
 
-        if function.__name__ not in self._functions:
-            self._functions[function.__name__] = function
+        function_name = function_name or function.__name__
+        if function_name not in self._functions:
+            self._functions[function_name] = function
         else:
             raise ExistingRegisteredFunctionError("A function with the same name is already registered.")
 

--- a/substratools/function.py
+++ b/substratools/function.py
@@ -82,12 +82,13 @@ class FunctionRegister:
     def __init__(self):
         self._functions = {}
 
-    def __call__(self, function: Callable, function_name: Optional = None):
+    def __call__(self, function: Callable, function_name: Optional[str] = None):
         """Function called when using an instance of the class as a decorator.
 
         Args:
             function (Callable): function to register in substratools.
-
+            function_name (str, optional): function name to register the given function.
+                If None, function.__name__ is used for registration.
         Raises:
             ExistingRegisteredFunctionError: Raise if a function with the same function.__name__
             has already been registered in substratools.


### PR DESCRIPTION
### Companion PR

https://github.com/Substra/substrafl/pull/59

### Description

The user can choose the name of the registered function to not use the function.__name__ (default behavior). Allow to use several time the same function but with a different name.