### PR TITLE
test: remove models and model from input and output identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Remove `model` and `models` for input and output identifiers in tests. Replace by `shared` instead. ([#84](https://github.com/Substra/substra-tools/pull/84))
+
 ### Added
 
 - Contributing, contributors & code of conduct files (#77)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,9 +77,8 @@ def output_model_path_2(workdir: Path) -> str:
 
 @pytest.fixture()
 def valid_function_workspace(output_model_path: str) -> FunctionWorkspace:
-
     workspace_outputs = TaskResources(
-        json.dumps([{"id": OutputIdentifiers.model, "value": str(output_model_path), "multiple": False}])
+        json.dumps([{"id": OutputIdentifiers.shared, "value": str(output_model_path), "multiple": False}])
     )
 
     workspace = FunctionWorkspace(outputs=workspace_outputs)

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -118,7 +118,7 @@ def wrong_saved_train(inputs, outputs, task_properties):
         new_model["value"] += m["value"]
 
     # save model
-    utils.wrong_save_model(model=new_model, path=outputs.get("model"))
+    utils.wrong_save_model(model=new_model, path=outputs.get(OutputIdentifiers.shared))
 
 
 @pytest.fixture

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,8 +10,6 @@ from substratools.task_resources import StaticInputIdentifiers
 class InputIdentifiers(str, Enum):
     local = "local"
     shared = "shared"
-    model = "model"
-    models = "models"
     predictions = "predictions"
     opener = StaticInputIdentifiers.opener.value
     datasamples = StaticInputIdentifiers.datasamples.value
@@ -21,7 +19,6 @@ class InputIdentifiers(str, Enum):
 class OutputIdentifiers(str, Enum):
     local = "local"
     shared = "shared"
-    model = "model"
     predictions = "predictions"
     performance = "performance"
 


### PR DESCRIPTION
## Summary

Remove models and model to input and output identifier to put only `shared_state`. This change help to improve the flexibility on workflows. In particular, it unlock the possibility to link train tasks with each other (needde in cyclic strategy for instance).

## Companion PR

- https://github.com/Substra/substrafl/pull/142 (main)
- https://github.com/Substra/substra/pull/367
- https://github.com/Substra/substra-tools/pull/84
- https://github.com/Substra/substra-tests/pull/261